### PR TITLE
Option to define directory where components are stored

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ export default users
 
 ```
 
+## Additional options
+
+```
+# Define directory with components
+$ add-react-component -d src Example
+```
+
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -24,12 +24,13 @@ const program = require('commander')
   .option('-f, --fn', 'Create Function Component')
   .option('-r, --redux', 'Create Redux Store')
   .option('-c, --css', `Add ${componentName}.css`)
+  .option('-d, --directory <directory>', 'Use directory')
   .parse(process.argv)
 
 createComponent(componentName)
 
 function createComponent (name) {
-  const rootDirectory = path.resolve(name)
+  const rootDirectory = program.directory ? path.join(path.resolve(program.directory), name) : path.resolve(name)
   const hasCSS = program.css
   const makeFn = program.fn
   const createStore = program.store


### PR DESCRIPTION
Hi. Thank you for the package! I would like to use it for my project.
But it was missing some features, so I was thinking if I can add them.

I would like to simplify the creation of components for my fellow developers so that they just run a simple command, and all the parameters will be embedded into my script. But for that, I need the package to support such parameters.

With `-d` parameter I would like to be able to define the directory where component to be stored. In my current project, it is `src` folder. With such parameter, it is possible to run `add-component` not only from inside the folder, but also from the root of the project.